### PR TITLE
fix rails 6 deprecation warning

### DIFF
--- a/lib/best_in_place/railtie.rb
+++ b/lib/best_in_place/railtie.rb
@@ -4,7 +4,7 @@ require 'action_view/base'
 module BestInPlace
   class Railtie < ::Rails::Railtie #:nodoc:
     config.after_initialize do
-      BestInPlace::ViewHelpers = ActionView::Base.new
+      BestInPlace::ViewHelpers = ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil)
     end
   end
 end


### PR DESCRIPTION
https://github.com/bernat/best_in_place/issues/611

```
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. ...
```